### PR TITLE
chore: add frontend tags autotag + skip nvim-tree to be on buffer tabs

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -22,6 +22,7 @@ require("lazy").setup({
 })
 -- Custom configuration
 require("custom.alpha_config")
+require("custom.autotag")
 require("custom.auto-session")
 require("custom.better-escape_config")
 require("custom.bufferline_config")

--- a/nvim/lua/custom/autotag.lua
+++ b/nvim/lua/custom/autotag.lua
@@ -1,0 +1,5 @@
+require('nvim-ts-autotag').setup({
+    autotag = {
+        enable = true,
+    }
+})

--- a/nvim/lua/custom/bufferline_config.lua
+++ b/nvim/lua/custom/bufferline_config.lua
@@ -39,7 +39,14 @@ bufferline.setup {
             delay = 150,
             reveal = { 'close' }
         },
-        sort_by = 'extension',
+        sort_by = 'directory',
+        custom_filter = function(buf_number)
+            local buf_name = vim.fn.bufname(buf_number)
+            if buf_name:match("NvimTree_") then
+                return false
+            end
+            return true
+        end,
     },
     highlights = {
         fill = {

--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -213,4 +213,8 @@ return {
         main = "ibl",
         opts = {}
     },
+    -- Html autoclose tag
+    {
+        'windwp/nvim-ts-autotag'
+    }
 }


### PR DESCRIPTION
- Add `nvim-ts-autotag` plugin
- Skip NvimTree tab to be present on bufferline